### PR TITLE
Bug fix - generateCalendars() is called without an event.id

### DIFF
--- a/add-to-calendar.js
+++ b/add-to-calendar.js
@@ -468,6 +468,9 @@
       console.error('Event details missing.');
       return;
     }
+    
+    // Get the event ID into params.data object before calling generateMarkup().
+    params.data.id = params.options.id;
 
     return generateMarkup(
       generateCalendars(params.data),


### PR DESCRIPTION
When I use `Download ical ` button, on a page that has multiple "add to calendar" widgets, the UID that is being generated is 
`UID:-https://www.mywebsite.com`
So all the events on that page - will have the same UID, and that is causing each ics download to override the previous events that were added to my calendar.

When I examined this, I found out that `generateCalendars()` was called without an event.id

This PR fixing that issue, and now the UID includes the random ID added before the url -
`UID:624696-https://www.mywebsite.com`